### PR TITLE
Added merging of keywords in DB

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     compile group: 'org.apache.commons', name: 'commons-compress', version: '1.20'
     compile group: 'org.json', name: 'json', version: '20200518'
     compile 'org.postgresql:postgresql:42.2.16'
+    compile 'org.neo4j.driver:neo4j-java-driver:4.1.1'
 }
 
 tasks {

--- a/java/src/main/java/science/icebreaker/network/Graph.java
+++ b/java/src/main/java/science/icebreaker/network/Graph.java
@@ -1,0 +1,33 @@
+package science.icebreaker.network;
+
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+
+public class Graph {
+    private static Graph database;
+    private Driver driver;
+
+    private Graph() {
+        final String URI = "neo4j://localhost:7687";
+        final String username = "neo4j";
+        final String password = "neo4j";
+        this.driver = GraphDatabase.driver(URI, AuthTokens.basic(username, password));
+    }
+
+    public static Graph getInstance() {
+        if(database == null)
+            database = new Graph();
+        
+        return database;
+    }
+
+    public Session getSession() {
+        return driver.session();
+    }
+
+	public void close() {
+        this.driver.close();
+	}
+}

--- a/java/src/main/java/science/icebreaker/network/Main.java
+++ b/java/src/main/java/science/icebreaker/network/Main.java
@@ -2,6 +2,7 @@ package science.icebreaker.network;
 
 import chen.chaoran.data_manager.core.Startable;
 import science.icebreaker.network.keyword_merge.programs.BaseKeywordMergeProgram;
+import science.icebreaker.network.keyword_merge.programs.MergeResultsInDBProgram;
 import science.icebreaker.network.wikidata.WikidataImporterMaster;
 
 import java.nio.file.Paths;
@@ -23,6 +24,7 @@ public class Main {
             {
                 put("WikidataImporter", WikidataImporterMaster.class);
                 put("KeywordMerge", BaseKeywordMergeProgram.class);
+                put("MergeInDB", MergeResultsInDBProgram.class);
             }
         };
 

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/AndSimilarityComparator.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/AndSimilarityComparator.java
@@ -21,7 +21,7 @@ public class AndSimilarityComparator extends SimilarityComparator {
             SimilarityResult res1 = comp1.compare(word1, word2, repository);
             if(!res1.isSimilar) return res1;
             SimilarityResult res2 = comp2.compare(word1, word2, repository);
-            if(!res1.equals(res2)) return new SimilarityResult(null, false); // Comparators inconsistent
+            if(!res1.equals(res2)) return new SimilarityResult(word1, word2, null, false); // Comparators inconsistent
             return res2;
         }
 }

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/NotSimilarityComparator.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/NotSimilarityComparator.java
@@ -20,7 +20,7 @@ public class NotSimilarityComparator extends SimilarityComparator {
     @Override
     public SimilarityResult compare(Keyword word1, Keyword word2, KeywordRepository repository) {
         SimilarityResult result = comp.compare(word1, word2, repository);
-        if(result.isSimilar) return new SimilarityResult(null, false);
-        else return new SimilarityResult(word1, true); //pick any word
+        if(result.isSimilar) return new SimilarityResult(word1, word2, null, false);
+        else return new SimilarityResult(word1, word2, word1, true); //pick any word
     }
 }

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/SimilarityComparatorUnit.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/SimilarityComparatorUnit.java
@@ -22,7 +22,7 @@ public class SimilarityComparatorUnit extends SimilarityComparator {
     public SimilarityResult compare(Keyword word1, Keyword word2, KeywordRepository repository) {
         SimilarityResult result; //TODO: if needed save repeated comparisons
         if(word1.equals(word2))
-            result = new SimilarityResult(word1, true);
+            result = new SimilarityResult(word1, word2, word1, true);
         else
             result = strategy.compare(word1, word2);
 

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/SimilarityResult.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/SimilarityResult.java
@@ -6,16 +6,24 @@ import science.icebreaker.network.keyword_merge.entities.Keyword;
  * Represents the result of comparing 2 keywords for similarity
  */
 public class SimilarityResult {
+    public final Keyword kw1;
+    public final Keyword kw2;
     // Useful for deciding a common root keyword(might come in handy when inserting new data)
     public final Keyword origin;
     public final Boolean isSimilar;
 
-    public SimilarityResult(Keyword origin, Boolean isSimilar) {
+    public SimilarityResult(Keyword kw1, Keyword kw2, Keyword origin, Boolean isSimilar) {
+        this.kw1 = kw1;
+        this.kw2 = kw2;
         this.origin = origin;
         this.isSimilar = isSimilar;
     }
 
     public boolean equals(SimilarityResult result) {
-        return origin.equals(result.origin) && (this.isSimilar == result.isSimilar);
+        return 
+            kw1.equals(result.kw1)
+            && kw2.equals(result.kw2)
+            && origin.equals(result.origin) 
+            && (this.isSimilar == result.isSimilar);
     }
 }

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/strategies/RemoveSplitCharsStrategy.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/strategies/RemoveSplitCharsStrategy.java
@@ -27,9 +27,9 @@ public class RemoveSplitCharsStrategy implements SimilarityComparisonStrategy {
         
         if(kw1.equals(kw2)) {
             Keyword longerWord = word1.keyword.length() >= word2.keyword.length() ? word1 : word2;
-            return new SimilarityResult(longerWord, true);
+            return new SimilarityResult(word1, word2, longerWord, true);
         }
-        else return new SimilarityResult(null, false);
+        else return new SimilarityResult(word1, word2, null, false);
     }
 
 }

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/strategies/SubsetStrategy.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/strategies/SubsetStrategy.java
@@ -23,11 +23,11 @@ public class SubsetStrategy implements SimilarityComparisonStrategy {
         Set<String> word2Fragments = new HashSet<String>(Arrays.asList(kw2.split(" ")));
         if(isSubset(word1Fragments, word2Fragments)) {
             if(word1Fragments.size() >= word2Fragments.size())
-                return new SimilarityResult(word1, true);
+                return new SimilarityResult(word1, word2, word1, true);
             else
-                return new SimilarityResult(word2, true);
+                return new SimilarityResult(word1, word2, word2, true);
         } 
-        else return new SimilarityResult(null, false);
+        else return new SimilarityResult(word1, word2, null, false);
     }
 
     private boolean isSubset(Set<String> word1Fragments, Set<String> word2Fragments) {

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/strategies/WordStemStrategy.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/comparators/strategies/WordStemStrategy.java
@@ -34,9 +34,9 @@ public class WordStemStrategy implements SimilarityComparisonStrategy {
 
         if(stemmedWord1.equals(stemmedWord2)) {
             Keyword shorterWord = kw1.length() <= kw2.length() ? word1 : word2;
-            return new SimilarityResult(shorterWord, true); // pick word1 wiki
+            return new SimilarityResult(word1, word2, shorterWord, true); // pick word1 wiki
         }
         else
-            return new SimilarityResult(null, false);
+            return new SimilarityResult(word1, word2, null, false);
     }
 }

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/comparison/ComparatorSpecification.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/comparison/ComparatorSpecification.java
@@ -42,7 +42,7 @@ public class ComparatorSpecification {
         SimilarityResult res = comparator.compare(word1, word2, repository);
 
         //resolve
-        if(res.isSimilar) resolver.merge(word1, word2, res.origin);
+        if(res.isSimilar) resolver.merge(res);
     }
 
     public void finish() {

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/entities/Keyword.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/entities/Keyword.java
@@ -13,4 +13,9 @@ public class Keyword {
     public String toString() {
         return this.keyword;
     }
+
+    @Override
+    public int hashCode() {
+        return this.keyword.hashCode();
+    }
 }

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/programs/MergeResultsInDBProgram.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/programs/MergeResultsInDBProgram.java
@@ -1,0 +1,35 @@
+package science.icebreaker.network.keyword_merge.programs;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.ListIterator;
+
+import chen.chaoran.data_manager.core.Startable;
+import science.icebreaker.network.keyword_merge.comparators.SimilarityResult;
+import science.icebreaker.network.keyword_merge.repository.KeywordRepository;
+import science.icebreaker.network.keyword_merge.repository.LoadFromCSVSimilarityLoader;
+import science.icebreaker.network.keyword_merge.repository.LoadFromDBRepository;
+import science.icebreaker.network.keyword_merge.repository.SimilarityResultLoader;
+import science.icebreaker.network.keyword_merge.resolvers.MergeInDBResolver;
+
+public class MergeResultsInDBProgram implements Startable {
+    private void merge(String[] mergeFilePaths) throws IOException {
+        KeywordRepository keywordRepo = new LoadFromDBRepository();
+        keywordRepo.load(); //load existing keywords from repo
+
+        SimilarityResultLoader loader = new LoadFromCSVSimilarityLoader(Arrays.asList(mergeFilePaths), keywordRepo);
+        loader.load(); //load similarity result CSV file
+
+        MergeInDBResolver resolver = new MergeInDBResolver(keywordRepo);
+        ListIterator<SimilarityResult> iterator = loader.getIterator(0);
+        iterator.forEachRemaining(resolver::merge); //for each similarity result, resolve it
+
+        resolver.resolveTransitiveMappings(); //if A refers to B and B refers to C change to A refers to C and B refers to C
+        resolver.propagateResultsToDB(loader.getNewKeywords()); //Persist results into db
+        resolver.end(); //cleanup DB inconsistencies
+    }
+
+    public void start(String[] args) throws IOException {
+        this.merge(args);
+    }
+}

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/repository/KeywordRepository.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/repository/KeywordRepository.java
@@ -15,4 +15,5 @@ public interface KeywordRepository {
     public abstract List<WikiData> getWikiDataByKeyword(Keyword keyword);
     public abstract void load();
     public abstract Keyword getKeywordByName(String name);
+	public abstract void addKeyword(Keyword keyword);
 }

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/repository/LoadFromCSVSimilarityLoader.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/repository/LoadFromCSVSimilarityLoader.java
@@ -1,0 +1,46 @@
+package science.icebreaker.network.keyword_merge.repository;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import science.icebreaker.network.keyword_merge.comparators.SimilarityResult;
+import science.icebreaker.network.keyword_merge.entities.Keyword;
+
+public class LoadFromCSVSimilarityLoader extends SimilarityResultLoader {
+    private List<String> fileDirs;
+
+    public LoadFromCSVSimilarityLoader(List<String> fileDirs, KeywordRepository keywordRepo) {
+        super(keywordRepo);
+        this.fileDirs = fileDirs;
+    }
+
+    @Override
+    public void load() {
+        for(String fileDir : this.fileDirs) {
+            Path pathToFile = Paths.get(fileDir);
+            try (BufferedReader br = Files.newBufferedReader(pathToFile)) {
+                String line = br.readLine();
+                while (line != null) {
+
+                    String[] attributes = line.split(",");
+                    //KW1, KW2, Suggested Sim Word, Merge Decision, Keyword To Merge
+                    Keyword kw1 = mergeKeyword(attributes[0]);
+                    Keyword kw2 = mergeKeyword(attributes[1]);
+                    Keyword origin = mergeKeyword(attributes[4]);
+                    boolean isSimilar = attributes[3].equals("true");
+                    SimilarityResult result = new SimilarityResult(kw1, kw2, origin, isSimilar);
+                    this.similarity.add(result);
+                    line = br.readLine();
+                }
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+        }
+
+    }
+    
+}

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/repository/LoadFromDBRepository.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/repository/LoadFromDBRepository.java
@@ -1,9 +1,11 @@
 package science.icebreaker.network.keyword_merge.repository;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 
 import science.icebreaker.network.Database;
 import science.icebreaker.network.keyword_merge.entities.Keyword;
@@ -22,11 +24,13 @@ public class LoadFromDBRepository implements KeywordRepository {
 
     private List<Iterator<Keyword>> keywordIterators; // may be used in the future for checkpoints
     private ArrayList<Keyword> keywords;
+    private Map<String, Keyword> keywordMap;
     private boolean loaded;
 
     public LoadFromDBRepository() {
         this.keywords = new ArrayList<Keyword>();
         this.keywordIterators = new ArrayList<Iterator<Keyword>>();
+        this.keywordMap = new HashMap<String, Keyword>();
         loaded = false;
     }
 
@@ -45,7 +49,7 @@ public class LoadFromDBRepository implements KeywordRepository {
 
     @Override
     public Keyword getKeywordByName(String name) {
-        throw new UnsupportedOperationException();
+        return this.keywordMap.get(name);
     }
 
     @Override
@@ -62,13 +66,21 @@ public class LoadFromDBRepository implements KeywordRepository {
             ResultSet rs;
             rs = stmt.executeQuery("SELECT name FROM keyword");
             while (rs.next()) {
-                String keyword = rs.getString("name");
-                this.keywords.add(new Keyword(keyword, null));
+                String keywordName = rs.getString("name");
+                Keyword keyword = new Keyword(keywordName, null);
+                this.keywords.add(keyword);
+                this.keywordMap.put(keywordName, keyword);
             }
         } catch (SQLException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
+    }
+
+    @Override
+    public void addKeyword(Keyword keyword) {
+        this.keywords.add(keyword);
+        this.keywordMap.put(keyword.keyword, keyword);
     }
     
 }

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/repository/SimilarityResultLoader.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/repository/SimilarityResultLoader.java
@@ -1,0 +1,43 @@
+package science.icebreaker.network.keyword_merge.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+
+import science.icebreaker.network.keyword_merge.comparators.SimilarityResult;
+import science.icebreaker.network.keyword_merge.entities.Keyword;
+
+public abstract class SimilarityResultLoader {
+    protected List<SimilarityResult> similarity;
+    private KeywordRepository keywordRepo;
+    private List<Keyword> newKeywords;
+
+    public SimilarityResultLoader(KeywordRepository keywordRepo) {
+        this.similarity = new ArrayList<SimilarityResult>();
+        this.newKeywords = new ArrayList<Keyword>();
+        this.keywordRepo = keywordRepo;
+    }
+
+    public List<Keyword> getNewKeywords() {
+        return newKeywords;
+    }
+
+    public abstract void load();
+
+    public ListIterator<SimilarityResult> getIterator(int index) {
+        return this.similarity.listIterator(index);
+    }
+
+    protected Keyword mergeKeyword(String keywordName) {
+        Keyword existingKeyword = this.keywordRepo.getKeywordByName(keywordName);
+
+        if(existingKeyword != null) return existingKeyword;
+        else {
+            Keyword newKeyword = new Keyword(keywordName, null);
+            this.newKeywords.add(newKeyword);
+
+            this.keywordRepo.addKeyword(newKeyword);
+            return newKeyword;
+        }
+    }
+}

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/resolvers/MergeInDBResolver.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/resolvers/MergeInDBResolver.java
@@ -1,0 +1,238 @@
+package science.icebreaker.network.keyword_merge.resolvers;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.TransactionWork;
+import org.neo4j.driver.internal.InternalNode;
+import org.neo4j.driver.Result;
+
+import science.icebreaker.network.Database;
+import science.icebreaker.network.Graph;
+import science.icebreaker.network.keyword_merge.comparators.SimilarityResult;
+import science.icebreaker.network.keyword_merge.entities.Keyword;
+import science.icebreaker.network.keyword_merge.repository.KeywordRepository;
+
+public class MergeInDBResolver implements SimilarityResultResolver {
+    /**
+     * Used for intermediate mapping. Ex: if keyword B is decided to be merged into
+     * keyword A and later on, Keyword C is decided to be merged into keyword B,
+     * this map can be used to map it to C instead
+     */
+    private Map<Keyword, Keyword> refersTo; // used for intermediate mapping
+    private KeywordRepository keywordRepo;
+
+    private PreparedStatement putKeywordRefStmt;
+    private PreparedStatement addNewKeywordStmt;
+    private PreparedStatement updateWeightStmt;
+
+    public MergeInDBResolver(KeywordRepository keywordRepo) {
+        this.keywordRepo = keywordRepo;
+        this.refersTo = new HashMap<Keyword, Keyword>();
+        try {
+            Connection conn = Database.getConnection();
+            putKeywordRefStmt = conn.prepareStatement(
+                "UPDATE keyword " 
+                + "SET refers_to=? "
+                + "WHERE name=?;"
+            );
+            addNewKeywordStmt = conn.prepareStatement(
+                "INSERT INTO keyword(name, weight) "
+                + "VALUES(?,0);"
+            );
+            updateWeightStmt = conn.prepareStatement(
+                "UPDATE keyword "
+                + "SET weight=? "
+                + "WHERE name=?;"
+            );
+        } catch (SQLException throwables) {
+            throw new RuntimeException(throwables);
+        }
+    }
+
+    public void merge(SimilarityResult result) {
+        if (!result.isSimilar)
+            return;
+
+        if (result.origin.equals(result.kw1)) {
+            this.mapWord(result.kw2, result.kw1);
+        } else if (result.origin.equals(result.kw2)) {
+            this.mapWord(result.kw1, result.kw2);
+        } else {
+            this.mapWord(result.kw1, result.origin);
+            this.mapWord(result.kw2, result.origin);
+        }
+    }
+
+    /**
+     * Maps word1 to word2 i.e. word2 is the base word and word1 is the alias
+     * 
+     * @param word1
+     * @param word2
+     */
+    public void mapWord(Keyword word1, Keyword word2) {
+        this.refersTo.put(word1, word2);
+    }
+
+    /**
+     * When keyword A is set to refer to keyword B and later on keyword B is set to
+     * refer to keyword C, A should be set to refer to C.
+     * 
+     * check if there are no transitive refersTo entries and adjust any if found.
+     */
+    public void resolveTransitiveMappings() {
+        for (Keyword word1 : this.refersTo.keySet()) {
+            Keyword parent = this.refersTo.get(word1);
+            if (parent == null)
+                continue; // root keyword
+
+            Keyword ancestor = getKeywordAncestor(parent);
+            if (parent != ancestor)
+                mapWord(word1, ancestor);
+        }
+    }
+
+    /**
+     * Gets the base keyword in a refersTo relation chain.
+     * 
+     * @param word the word to get the ancestor of
+     * @return the base keyword
+     */
+    private Keyword getKeywordAncestor(Keyword word) {
+        Keyword next = this.refersTo.getOrDefault(word, word);
+        if (next == word)
+            return next;
+        else
+            return getKeywordAncestor(next);
+    }
+
+    public void propagateResultsToDB(List<Keyword> newKeywords) {
+        // add non existing keywords
+        for (Keyword newKeyword : newKeywords) {
+            // sql side
+            try {
+                this.addNewKeywordStmt.setString(1, newKeyword.keyword);
+                this.addNewKeywordStmt.execute();
+            } catch (SQLException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+
+            try (Session session = Graph.getInstance().getSession()) {
+                session.writeTransaction(new TransactionWork<Void>() {
+                    @Override
+                    public Void execute(Transaction tx) {
+                        Map<String, Object> params = new HashMap<>();
+                        params.put("name", newKeyword.keyword);
+                        tx.run("CREATE (:Topic {name:$name, weight:0})", params);
+                        return null;
+                    }
+
+                });
+            }
+
+        }
+
+        for (Entry<Keyword, Keyword> entry : this.refersTo.entrySet()) {
+            // SQL Side
+            try {
+                // Put the sql entry
+                this.putKeywordRefStmt.setString(1, entry.getValue().keyword);
+                this.putKeywordRefStmt.setString(2, entry.getKey().keyword);
+                this.putKeywordRefStmt.execute();
+            } catch (SQLException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+
+            // Graph Side
+            try (Session session = Graph.getInstance().getSession()) {
+                session.writeTransaction(new TransactionWork<Void>() {
+                    @Override
+                    public Void execute(Transaction tx) {
+                        Map<String, Object> params = new HashMap<>();
+                        params.put("parent", entry.getValue().keyword);
+                        params.put("child", entry.getKey().keyword);
+
+                        // add intersecting papers weight
+                        /**
+                         * Since weights are collected at the end, both relation and node weights can be
+                         * lists or numbers to be safe, convert both to lists and concatenate. the
+                         * transaction query ran at the end will collect the weights
+                         */
+                        tx.run("MATCH (p:Topic { name: $parent })-[rel:RELATED_TO]-(c:Topic { name: $child }) "
+                                + "WITH reduce(a = [], rW IN rel.weight | a + -rW) as listRelW, p "
+                                + "WITH reduce(acc = [], pW IN p.weight | acc + pW) as pRelW, listRelW, p "
+                                + "SET p.weight = pRelW + listRelW", params);
+
+                        /**
+                         * Merge the nodes while combining weight and edge references and dropping all
+                         * names except for the parent's
+                         */
+                        tx.run("MATCH (n1:Topic { name: $parent }), (n2:Topic { name: $child }) "
+                                + "WITH head(collect([n1, n2])) as nodes " + "CALL apoc.refactor.mergeNodes(nodes,{ "
+                                + "  properties: { " + "      name:'discard', " + "      weight:'combine', "
+                                + "      references:'combine' " + "    }, " + "   mergeRels:true " + "}) "
+                                + "YIELD node " + "RETURN count(*) ", params);
+                        return null;
+                    }
+
+                });
+            }
+        }
+    }
+
+    public void end() {
+        try (Session session = Graph.getInstance().getSession()) {
+
+            // cleanup the graph
+            session.writeTransaction(new TransactionWork<Void>() {
+                @Override
+                public Void execute(Transaction tx) {
+                    // remove self relationships
+                    tx.run("MATCH (n:Topic)-[r:RELATED_TO]-(n:Topic) " + "DELETE r");
+
+                    // add up relationship weights
+                    tx.run("MATCH (:Topic)-[r:RELATED_TO]-(:Topic) " + "SET r.weight = size(r.references)");
+
+                    // add up node weights
+                    Result result = tx
+                            .run("MATCH (n:Topic) " + "SET n.weight = reduce(base = 0, w IN n.weight | base + w) "
+                                    + "WITH COLLECT(n) as nodes " + "RETURN nodes");
+
+                    //add 
+                    while (result.hasNext()) {
+                        Map<String, Object> row = result.next().asMap();
+                        for (Entry<String, Object> column : row.entrySet()) {
+                            List<InternalNode> nodesList = (List<InternalNode>) column.getValue();
+                            nodesList.forEach(nodeMap -> {
+                                Map<String, Object> map = nodeMap.asMap();
+                                String name = (String) map.get("name");
+                                Long weight = (Long) map.get("weight");
+                                try {
+                                    updateWeightStmt.setLong(1, weight);
+                                    updateWeightStmt.setString(2, name);
+                                    updateWeightStmt.execute();
+                                } catch (SQLException e) {
+                                    // TODO Auto-generated catch block
+                                    e.printStackTrace();
+                                }
+                            });
+                        }
+                    }
+                    return null;
+                }
+                
+            });
+
+            Graph.getInstance().close();
+        }
+    }
+}

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/resolvers/SimilarityResultResolver.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/resolvers/SimilarityResultResolver.java
@@ -1,11 +1,11 @@
 package science.icebreaker.network.keyword_merge.resolvers;
 
-import science.icebreaker.network.keyword_merge.entities.Keyword;
+import science.icebreaker.network.keyword_merge.comparators.SimilarityResult;
 
 /**
  * Provides functionality for resolving merge results generated from comparators
  */
 public interface SimilarityResultResolver {
-	void merge(Keyword word1, Keyword word2, Keyword origin);
-	void end();
+    void merge(SimilarityResult result);
+    void end();
 }

--- a/java/src/main/java/science/icebreaker/network/keyword_merge/resolvers/WriteToFileResolver.java
+++ b/java/src/main/java/science/icebreaker/network/keyword_merge/resolvers/WriteToFileResolver.java
@@ -4,7 +4,7 @@ import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import science.icebreaker.network.keyword_merge.entities.Keyword;
+import science.icebreaker.network.keyword_merge.comparators.SimilarityResult;
 
 public class WriteToFileResolver implements SimilarityResultResolver {
 
@@ -19,9 +19,9 @@ public class WriteToFileResolver implements SimilarityResultResolver {
     }
 
     @Override
-    public void merge(Keyword word1, Keyword word2, Keyword origin) {
+    public void merge(SimilarityResult result) {
         try {
-            this.BW.write(word1.keyword + "," + word2.keyword + "," + origin.keyword + "\n");
+            this.BW.write(result.kw1.keyword + "," + result.kw2.keyword + "," + result.origin.keyword + "\n");
             counter++;
 
             // Report results once in a while

--- a/postgresql/scripts/add_keyword_alias.sql
+++ b/postgresql/scripts/add_keyword_alias.sql
@@ -1,0 +1,7 @@
+ALTER TABLE keyword
+    ADD COLUMN refers_to text;
+
+ALTER TABLE keyword 
+   ADD CONSTRAINT fk_keyword
+   FOREIGN KEY (refers_to)
+   REFERENCES keyword(name);


### PR DESCRIPTION
Closes #1 

Make sure to execute the SQL script to add the `refers_to` column to the DB first

To run the program use the following arguments
`MergeInDB ${...pathToCSVFiles}`

The program is not fully idempotent due to the time and difficulty that would go into implementing this across 2 different DBs so make sure to run it to termination.

